### PR TITLE
Added owner and version field to the DLHub block

### DIFF
--- a/schemas/dlhub.json
+++ b/schemas/dlhub.json
@@ -4,7 +4,7 @@
     "description": "General metadata for the DLHub service",
     "type": "object",
     "properties": {
-        "dlhub_version": {
+        "version": {
             "type": "string",
             "description": "Version of the DLHub service"
         },
@@ -93,6 +93,6 @@
             "enum": ["servable", "dataset", "pipeline"]
         }
     },
-    "required": ["dlhub_version", "name"],
+    "required": ["version", "name", "type"],
     "additionalProperties": false
 }

--- a/schemas/dlhub.json
+++ b/schemas/dlhub.json
@@ -4,16 +4,25 @@
     "description": "General metadata for the DLHub service",
     "type": "object",
     "properties": {
-        "version": {
+        "dlhub_version": {
             "type": "string",
             "description": "Version of the DLHub service"
         },
+        "version": {
+            "type": "string",
+            "description": "Version of the DLHub artifact"
+        }, 
         "domains": {
             "type": "array",
             "description": "Scientific application areas of the artifact",
             "item_type": {
                 "type": "string"
             }
+        },
+        "owner": {
+            "type": "string",
+            "description": "Globus ID of the owner of the model",
+            "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
         },
         "name": {
             "type": "string",

--- a/schemas/dlhub.json
+++ b/schemas/dlhub.json
@@ -9,9 +9,8 @@
             "description": "Version of the DLHub service"
         },
         "publication_date": {
-            "type": "string",
-            "description": "Time when this model was submitted to DLHub.",
-            "format": "date-time"
+            "type": "integer",
+            "description": "Time when this model was submitted to DLHub, expressed as a UNIX timestamp (seconds from the Unix Epoch)"
         }, 
         "domains": {
             "type": "array",
@@ -49,7 +48,7 @@
             }
         },
         "id": {
-            "description": "Unique identifier for this artifact in DLHub",
+            "description": "Unique identifier for this artifact in DLHub. Used internally",
             "anyOf": [
                 {"type": "null"},
                 {
@@ -87,6 +86,11 @@
         "test": {
             "type": "boolean",
             "description": "Internal use. Whether DLHub is actually going to do anything other than validate the request"
+        },
+        "type": {
+            "type": "string",
+            "description": "Type of this artifact.",
+            "enum": ["servable", "dataset", "pipeline"]
         }
     },
     "required": ["dlhub_version", "name"],

--- a/schemas/dlhub.json
+++ b/schemas/dlhub.json
@@ -21,8 +21,7 @@
         },
         "owner": {
             "type": "string",
-            "description": "Globus ID of the owner of the model",
-            "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+            "description": "Namespace of the owner of the model. Generally the email address minus the @ symbol and domain."
         },
         "name": {
             "type": "string",

--- a/schemas/dlhub.json
+++ b/schemas/dlhub.json
@@ -8,9 +8,10 @@
             "type": "string",
             "description": "Version of the DLHub service"
         },
-        "version": {
+        "publication_date": {
             "type": "string",
-            "description": "Version of the DLHub artifact"
+            "description": "Time when this model was submitted to DLHub.",
+            "format": "date-time"
         }, 
         "domains": {
             "type": "array",
@@ -88,6 +89,6 @@
             "description": "Internal use. Whether DLHub is actually going to do anything other than validate the request"
         }
     },
-    "required": ["version", "name"],
+    "required": ["dlhub_version", "name"],
     "additionalProperties": false
 }


### PR DESCRIPTION
This PR formalizes how we store the owner of an artifact and the version number in the schema.

The owner name is specified using the UUID of the owner's primary identity in Globus. While not human-friendly, it will be resilient for people changing their display name on DLHub. @ryanchard, what would help searching is a HTTP endpoint to get a user display name given UUID. Is that feasible?

The version number is specified as a string. My thought is that we would use the field to store a date-time. Given that (1) could we sort datetime strings by time if they are stored as strings, (2) should we call it "submission_date" instead of "version", and (3) should I use a datetime type for clarity? (@jgaff , any thoughts?)